### PR TITLE
Added remove ACTION to studierbot/drive/udev/77-evo-slcand.rules

### DIFF
--- a/studierbot/drive/udev/77-evo-slcand.rules
+++ b/studierbot/drive/udev/77-evo-slcand.rules
@@ -1,2 +1,3 @@
 # USBtin module
 ACTION=="add", ENV{SUBSYSTEM}=="tty", GROUP="dialout", MODE="0666", ATTRS{product}=="USBtin", RUN+="/usr/bin/logger [udev] USBtin detected, creating symlink ttyEvoCan ", SYMLINK+="ttyEvoCan"
+ACTION=="remove",  ENV{ID_SERIAL_SHORT}=="A0212656",   RUN+="/usr/bin/pkill slcand"


### PR DESCRIPTION
Added automatic pkill scland ACTION when USBtin is removed to its udev rule. Wenn scland nicht läuft gibt pkill einfach nix zurück, deswegen auch keine Nachteile.