### PR TITLE
Modify udev rule for USBtin to make can_up.sh unnecessary

### DIFF
--- a/studierbot/interface/can/77-evo-slcand.rules
+++ b/studierbot/interface/can/77-evo-slcand.rules
@@ -1,3 +1,3 @@
 # USBtin module
-ACTION=="add", ENV{SUBSYSTEM}=="tty", GROUP="dialout", MODE="0666", ATTRS{product}=="USBtin", RUN+="/usr/bin/logger [udev] USBtin detected, creating symlink ttyEvoCan ", SYMLINK+="ttyEvoCan"
-ACTION=="remove",  ENV{ID_SERIAL_SHORT}=="A0212656",   RUN+="/usr/bin/pkill slcand"
+ACTION=="add", ENV{SUBSYSTEM}=="tty", GROUP="dialout", MODE="0666", ATTRS{product}=="USBtin", RUN+="/usr/bin/logger [udev] USBtin detected, creating symlink ttyEvoCan ", SYMLINK+="ttyEvoCan", ENV{SYSTEMD_WANTS}="slcand.service"
+#ACTION=="remove",  ENV{ID_SERIAL_SHORT}=="A0212656",   RUN+="/usr/bin/pkill slcand"

--- a/studierbot/interface/can/Makefile
+++ b/studierbot/interface/can/Makefile
@@ -1,0 +1,10 @@
+all:
+		echo 'No rule for make all existing. Please run "sudo make install" to install the udev rule and systemd service.'
+
+install:
+		install -D -m644 77-evo-slcand.rules /etc/udev/rules.d/77-evo-slcand.rules
+		install -D -m644 slcand.service /etc/systemd/system/slcand.service
+
+remove:
+		remove /etc/udev/rules.d/77-evo-slcand.rules
+		remove /etc/systemd/system/slcand.service

--- a/studierbot/interface/can/slcand.service
+++ b/studierbot/interface/can/slcand.service
@@ -1,0 +1,10 @@
+[Unit]
+BindsTo=dev-ttyEvoCan.device
+After=dev-ttyEvoCan.device
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/slcand -F -f -s6 -o -c /dev/ttyEvoCan
+ExecStartPost=ip link set slcan0 up
+User=root
+Group=root

--- a/studierbot/interface/can/slcand.service
+++ b/studierbot/interface/can/slcand.service
@@ -5,6 +5,6 @@ After=dev-ttyEvoCan.device
 [Service]
 Type=simple
 ExecStart=/usr/bin/slcand -F -f -s6 -o -c /dev/ttyEvoCan
-ExecStartPost=ip link set slcan0 up
+ExecStartPost=/bin/ip link set slcan0 up
 User=root
 Group=root


### PR DESCRIPTION
Modify udev rule for USBtin USB to CAN converter and add systemd service so that on plugging in the slcan0 interface gets set up automatically and stopped when plugged out.